### PR TITLE
feature: capability to add extra kubernetes manifests

### DIFF
--- a/charts/py-app/templates/deployment.yaml
+++ b/charts/py-app/templates/deployment.yaml
@@ -49,6 +49,9 @@ spec:
           {{- with .Values.probes.readiness }}
           readinessProbe: {{ . | toYaml | nindent 12 }}
           {{- end }}
+          {{- with .Values.probes.startup }}
+          startupProbe: {{ . | toYaml | nindent 12 }}
+          {{- end }}
           {{- include "py-app.envs" . | indent 10 -}}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/charts/py-app/templates/deployment.yaml
+++ b/charts/py-app/templates/deployment.yaml
@@ -8,6 +8,7 @@ metadata:
 spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit | default 5 }}
   {{- end }}
   {{- with .Values.updateStrategy }}
   strategy:
@@ -53,6 +54,9 @@ spec:
           startupProbe: {{ . | toYaml | nindent 12 }}
           {{- end }}
           {{- include "py-app.envs" . | indent 10 -}}
+          {{- with .Values.securityContext }}
+          securityContext: {{ . | toYaml | nindent 12 }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
 

--- a/charts/py-app/templates/extra-objects.yaml
+++ b/charts/py-app/templates/extra-objects.yaml
@@ -1,0 +1,6 @@
+{{- if .Values.extraManifests }}
+{{- range .Values.extraManifests }}
+---
+{{ toYaml . }}
+{{- end }}
+{{- end }}

--- a/charts/py-app/templates/limitrange.yaml
+++ b/charts/py-app/templates/limitrange.yaml
@@ -6,5 +6,7 @@ metadata:
   labels:
     {{- include "py-app.labels" . | nindent 4 }}
 spec:
-  limits: {{ .Values.limitRange.limits | toYaml | nindent 2 }}
+  {{- with .Values.limitRange.limits }}
+  limits: {{ . | toYaml | nindent 2 }}
+  {{- end }}
 {{- end -}}

--- a/charts/py-app/templates/limitrange.yaml
+++ b/charts/py-app/templates/limitrange.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.limitRange.create }}
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: {{ include "py-app.fullname" . }}
+  labels:
+    {{- include "py-app.labels" . | nindent 4 }}
+spec:
+  limits: {{ .Values.limitRange.limits | toYaml | nindent 2 }}
+{{- end -}}

--- a/charts/py-app/templates/taskiq-scheduler.yaml
+++ b/charts/py-app/templates/taskiq-scheduler.yaml
@@ -33,5 +33,5 @@ spec:
           command: {{ .Values.taskiq.schedulerCmd | toYaml | nindent 10 }}
           {{- include "py-app.envs" . | indent 10 -}}
           resources:
-            {{- toYaml .Values.resources | nindent 12 }}
+            {{- toYaml .Values.taskiq.resources | nindent 12 }}
 {{- end }}

--- a/charts/py-app/templates/taskiq-worker.yaml
+++ b/charts/py-app/templates/taskiq-worker.yaml
@@ -39,5 +39,5 @@ spec:
           command: {{ .Values.taskiq.workerCmd | toYaml | nindent 10 }}
           {{- include "py-app.envs" . | indent 10 -}}
           resources:
-            {{- toYaml .Values.resources | nindent 12 }}
+            {{- toYaml .Values.taskiq.resources | nindent 12 }}
 {{- end }}

--- a/charts/py-app/values.yaml
+++ b/charts/py-app/values.yaml
@@ -126,4 +126,13 @@ autoscaling:
   targetCPUUtilizationPercentage: 80
   # targetMemoryUtilizationPercentage: 80
 
+limitRange:
+  create: false
+  # limits:
+  #   - default:
+  #       memory: 700Mi
+  #     defaultRequest:
+  #       cpu: 50m
+  #       memory: 500Mi
+  #     type: Container
 extraManifests: []

--- a/charts/py-app/values.yaml
+++ b/charts/py-app/values.yaml
@@ -30,6 +30,7 @@ ttlSecondsAfterFinished: 3600
 taskiq:
   workerCmd: []
   schedulerCmd: []
+  resources: {}
   workers: 1
   autoscaling:
     enabled: false

--- a/charts/py-app/values.yaml
+++ b/charts/py-app/values.yaml
@@ -125,3 +125,5 @@ autoscaling:
   maxReplicas: 20
   targetCPUUtilizationPercentage: 80
   # targetMemoryUtilizationPercentage: 80
+
+extraManifests: []


### PR DESCRIPTION
example usage:

```yaml
extraManifests:
  # place raw kubernetes manifest here
  - apiVersion: v1
    kind: LimitRange
    metadata:
      annotations:
        argocd.argoproj.io/sync-wave: "10"
      name: default-limit-range
    spec:
      limits:
      - default:
          memory: 700Mi
        defaultRequest:
          cpu: 50m
          memory: 500Mi
        type: Container
```
this will be rendered in the template when installing the chart

partOf: https://github.com/Intreecom/ArgoCD/issues/904