### PR TITLE
fix: corrected targetPort value

### DIFF
--- a/charts/py-app/templates/static-service.yaml
+++ b/charts/py-app/templates/static-service.yaml
@@ -9,7 +9,7 @@ spec:
   type: ClusterIP
   ports:
     - port: {{ .Values.service.port }}
-      targetPort: {{ .Values.service.targetPort | default "static-service" }}
+      targetPort: {{ .Values.service.targetPort | default .Values.service.port }}
       protocol: TCP
       name: static-service
   selector:


### PR DESCRIPTION
finding: The `targetPort` name is same as `containers[*].ports[*].name` from deployment/pod definition and not `spec.ports[*].name` from service definition
