### PR TITLE
Gate taskiq instrumentation labels and annotations behind `taskiq.instrumentation.enabled` flag.

### DIFF
--- a/charts/py-app/templates/taskiq-scheduler.yaml
+++ b/charts/py-app/templates/taskiq-scheduler.yaml
@@ -13,14 +13,16 @@ spec:
       deployment_type: tkq-scheduler
   template:
     metadata:
-      {{- $podAnnotations := merge (deepCopy (default dict .Values.podAnnotations)) (default dict .Values.instrumentation.annotations) }}
+      {{- $instrumentationAnnotations := ternary (default dict .Values.instrumentation.annotations) dict .Values.taskiq.instrumentation.enabled }}
+      {{- $podAnnotations := merge (deepCopy (default dict .Values.podAnnotations)) $instrumentationAnnotations }}
       {{- with $podAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- $baseSelectorLabels := (include "py-app.selectorLabels" . | fromYaml) }}
       {{- $_ := set $baseSelectorLabels "deployment_type" "tkq-scheduler" }}
-      {{- $mergedLabels := merge $baseSelectorLabels (default dict .Values.instrumentation.labels) }}
+      {{- $instrumentationLabels := ternary (default dict .Values.instrumentation.labels) dict .Values.taskiq.instrumentation.enabled }}
+      {{- $mergedLabels := merge $baseSelectorLabels $instrumentationLabels }}
       labels:
         {{- toYaml $mergedLabels | nindent 8 }}
     spec:

--- a/charts/py-app/templates/taskiq-worker.yaml
+++ b/charts/py-app/templates/taskiq-worker.yaml
@@ -19,14 +19,16 @@ spec:
       deployment_type: tkq-worker
   template:
     metadata:
-      {{- $podAnnotations := merge (deepCopy (default dict .Values.podAnnotations)) (default dict .Values.instrumentation.annotations) }}
+      {{- $instrumentationAnnotations := ternary (default dict .Values.instrumentation.annotations) dict .Values.taskiq.instrumentation.enabled }}
+      {{- $podAnnotations := merge (deepCopy (default dict .Values.podAnnotations)) $instrumentationAnnotations }}
       {{- with $podAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- $baseSelectorLabels := (include "py-app.selectorLabels" . | fromYaml) }}
       {{- $_ := set $baseSelectorLabels "deployment_type" "tkq-worker" }}
-      {{- $mergedLabels := merge $baseSelectorLabels (default dict .Values.instrumentation.labels) }}
+      {{- $instrumentationLabels := ternary (default dict .Values.instrumentation.labels) dict .Values.taskiq.instrumentation.enabled }}
+      {{- $mergedLabels := merge $baseSelectorLabels $instrumentationLabels }}
       labels:
         {{- toYaml $mergedLabels | nindent 8 }}
     spec:

--- a/charts/py-app/values.yaml
+++ b/charts/py-app/values.yaml
@@ -37,6 +37,8 @@ taskiq:
   schedulerCmd: []
   resources: {}
   workers: 1
+  instrumentation:
+    enabled: false
   autoscaling:
     enabled: false
     minReplicas: 1


### PR DESCRIPTION
Signed-off-by: Dev Jadeja <dev@intree.com>
